### PR TITLE
Add option to use IMDSv2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,13 @@ resource "aws_launch_configuration" "main" {
   user_data            = var.user_data
   user_data_base64     = var.user_data_base64
 
+  metadata_options {
+    # Require use of IMDSv2
+    http_endpoint = "enabled"
+    http_put_response_hop_limit = 1
+    http_tokens = var.require_imdsv2 ? "required" : "optional"
+  }
+
   dynamic "ebs_block_device" {
     iterator = device
     for_each = var.ebs_block_devices

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "instance_volume_size" {
   default     = 30
 }
 
+variable "require_imdsv2" {
+  description = "Require instances to use Instance Metadata Service V2"
+  type = bool
+  default = false
+}
+
 variable "ebs_block_devices" {
   description = "Additional EBS block devices to attach to the instance."
   type        = list(map(string))

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.22.0"
+    }
+  }
 }


### PR DESCRIPTION
### Changes

#### Add option to use imdsv2

Version 2 of IMDS protects against a number of vulnerabilities.
For more info, see: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8

#### Update required terraform and AWS provider version

The metadata option was first introduced in version 3.22.0 of the AWS provider,
and the terraform version is required to allow for the require_providers syntax.