### PR TITLE
Fix EC2 docker not being able to access IMDS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "aws_launch_configuration" "main" {
   metadata_options {
     # Require use of IMDSv2
     http_endpoint = "enabled"
-    http_put_response_hop_limit = 1
+    http_put_response_hop_limit = var.imdsv2_hops
     http_tokens = var.require_imdsv2 ? "required" : "optional"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "require_imdsv2" {
   default = false
 }
 
+variable "imdsv2_hops" {
+  description = "How many hops to allow for IMDSv2 token requests."
+  type = number
+  default = 1
+}
+
 variable "ebs_block_devices" {
   description = "Additional EBS block devices to attach to the instance."
   type        = list(map(string))


### PR DESCRIPTION
With docker containers on a EC2 host, the docker container could not get the session token. By increasing the hop limit, we allow the request to hop from docker to the host and then to AWS.